### PR TITLE
fix: improve concurrent behavior of removeNode and removeConnection

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -115,14 +115,13 @@ export class NodeEditor<Scheme extends BaseSchemes> extends Scope<Root<Scheme>> 
    * @emits noderemoved
    */
   async removeNode(id: Scheme['Node']['id']) {
-    const index = this.nodes.findIndex(n => n.id === id)
-    const node = this.nodes[index]
+    const node = this.nodes.find(n => n.id === id)
 
-    if (index < 0) throw new Error('cannot find node')
+    if (!node) throw new Error('cannot find node')
 
     if (!await this.emit({ type: 'noderemove', data: node })) return false
 
-    this.nodes.splice(index, 1)
+    this.nodes = this.nodes.filter(n => n !== node)
 
     await this.emit({ type: 'noderemoved', data: node })
     return true
@@ -137,14 +136,13 @@ export class NodeEditor<Scheme extends BaseSchemes> extends Scope<Root<Scheme>> 
    * @emits connectionremoved
    */
   async removeConnection(id: Scheme['Connection']['id']) {
-    const index = this.connections.findIndex(n => n.id === id)
-    const connection = this.connections[index]
+    const connection = this.connections.find(c => c.id === id)
 
-    if (index < 0) throw new Error('cannot find connection')
+    if (!connection) throw new Error('cannot find connection')
 
     if (!await this.emit({ type: 'connectionremove', data: connection })) return false
 
-    this.connections.splice(index, 1)
+    this.connections = this.connections.filter(c => c !== connection)
 
     await this.emit({ type: 'connectionremoved', data: connection })
     return true

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -63,6 +63,24 @@ describe('NodeEditor', () => {
     expect(nodes).toHaveLength(0)
   })
 
+  it('removeNode should remove specified nodes', async () => {
+    const editor = new NodeEditor()
+
+    const ids = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10']
+
+    await Promise.all(ids.map(id => editor.addNode({ id: id })))
+
+    const removeIds = ['1', '2', '3', '4', '5']
+
+    await Promise.all(removeIds.map(id => editor.removeNode(id)))
+
+    const remainIds = editor.getNodes().map(n => n.id)
+
+    await editor.clear()
+
+    expect(remainIds).toEqual(['6', '7', '8', '9', '10'])
+  })
+
   it('removeConnection should remove a connection', async () => {
     const editor = new NodeEditor()
     const connectionData = { id: '1', source: '1', target: '2' }
@@ -74,6 +92,26 @@ describe('NodeEditor', () => {
     const connections = editor.getConnections()
 
     expect(connections).toHaveLength(0)
+  })
+
+  it('removeConnection should remove specified connections', async () => {
+    const editor = new NodeEditor()
+
+    const ids = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10']
+
+    await Promise.all(ids.map(id => editor.addNode({ id: `s${id}` })))
+    await Promise.all(ids.map(id => editor.addNode({ id: `t${id}` })))
+    await Promise.all(ids.map(id => editor.addConnection({ id: id, source: `s${id}`, target: `t${id}` })))
+
+    const removeIds = ['1', '2', '3', '4', '5']
+
+    await Promise.all(removeIds.map(id => editor.removeConnection(id)))
+
+    const remainIds = editor.getConnections().map(c => c.id)
+
+    await editor.clear()
+
+    expect(remainIds).toEqual(['6', '7', '8', '9', '10'])
   })
 
   it('should clear all nodes and connections', async () => {


### PR DESCRIPTION
### Description

<!-- Describe the changes you've made. Include any relevant context or information. -->
This commit improves the concurrent behavior of removeNode and removeConnection.

In the previous code, removing multiple nodes or connections required awaiting each remove call inside a loop.
This may not be recommended depending on the linter configuration.
ref. https://eslint.org/docs/latest/rules/no-await-in-loop

### Related Issues

<!-- If your pull request is related to any GitHub issue(s), mention them here. -->
https://github.com/retejs/rete/issues/720

### Checklist

<!-- Mark the items that apply to this pull request -->

- [ ] I have read and followed [the contribution guidelines](https://retejs.org/docs/contribution#contribution).
- [x] I have [tested my changes](https://github.com/retejs/rete-qa) locally.
- [ ] I have updated [documentation](https://github.com/retejs/retejs.org) accordingly (if necessary).
- [ ] I have added unit and [E2E](https://github.com/retejs/rete-qa) tests (if applicable).

### Additional Notes

<!-- Any additional information or notes for the reviewers. -->
Sorry, I wasn't able to run rete-qa tests due to installation errors. (Maybe my PC doesn't have enough memory...)